### PR TITLE
拆包

### DIFF
--- a/blog-view/vue.config.js
+++ b/blog-view/vue.config.js
@@ -10,5 +10,29 @@ module.exports = {
 				'plugins': '@/plugins'
 			}
 		}
-	}
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				vendor: {
+					test: /[\\/]node_modules[\\/]/,
+					name(module) {
+						// get the name. E.g. node_modules/packageName/not/this/part.js
+						// or node_modules/packageName
+						const packageName = module.context.match(
+							/[\\/]node_modules[\\/](.*?)([\\/]|$)/
+						)[1];
+						// npm package names are URL-safe, but some servers don't like @ symbols
+						return `npm.${packageName.replace("@", "")}`;
+					},
+					chunks: "all",
+					enforce: true,
+					priority: 10,
+					minSize: 50000, // 50KB
+					maxSize: 200000,
+					reuseExistingChunk: true,
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
有构建后的js大小超过400kb（gzip），会阻塞网络，所以需要拆包优化大小，现在js优化后最大的js大概120+kb，不能更小的原因是elementui有个单文件是这么大，无法更小拆分