### PR TITLE
fix: 修复blogs接口在手动删除redis数据库后抛出异常错误500问题

### DIFF
--- a/blog-api/src/main/java/top/naccl/service/impl/BlogServiceImpl.java
+++ b/blog-api/src/main/java/top/naccl/service/impl/BlogServiceImpl.java
@@ -26,10 +26,7 @@ import top.naccl.util.JacksonUtils;
 import top.naccl.util.markdown.MarkdownUtils;
 
 import javax.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @Description: 博客文章业务层实现
@@ -130,7 +127,8 @@ public class BlogServiceImpl implements BlogService {
 		PageHelper.startPage(pageNum, pageSize, orderBy);
 		List<BlogInfo> blogInfos = processBlogInfosPassword(blogMapper.getBlogInfoListByIsPublished());
 		PageInfo<BlogInfo> pageInfo = new PageInfo<>(blogInfos);
-		PageResult<BlogInfo> pageResult = new PageResult<>(pageInfo.getPages(), pageInfo.getList());
+//		PageResult<BlogInfo> pageResult = new PageResult<>(pageInfo.getPages(), pageInfo.getList());
+		PageResult<BlogInfo> pageResult = new PageResult<>(pageInfo.getPages(), new ArrayList<>(pageInfo.getList()));
 		setBlogViewsFromRedisToPageResult(pageResult);
 		//添加首页缓存
 		redisService.saveKVToHash(redisKey, pageNum, pageResult);


### PR DESCRIPTION
### 问题复现方法
手动删除Redis数据库后访问/blogs接口 报错{"code":500,"msg":"异常错误","data":null}

### 问题说明
原有代码在缓存中保存了 PageResult，但读取出来后 BlogInfo 的结构不一致，导致序列化异常。

### 修复方式
调整了缓存的序列化处理逻辑，确保缓存读取后格式正确。